### PR TITLE
fix #24

### DIFF
--- a/MEQP1/ruleset.xml
+++ b/MEQP1/ruleset.xml
@@ -297,10 +297,6 @@
         <severity>6</severity>
         <type>warning</type>
     </rule>
-    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
-        <severity>6</severity>
-        <type>warning</type>
-    </rule>
     <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine">
         <severity>6</severity>
         <type>warning</type>


### PR DESCRIPTION
Remove the PSR1.Classes.ClassDeclaration.MissingNamespace from the M1 ruleset