### PR TITLE
MM-623: Move MEQP coding standards to repo.magento.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,45 +17,45 @@ and many others.
 
 **Magento Extension Quality Program Coding Standard** consists of two rulesets - MEQP1 for Magento and MEQP2 for Magento 2. Each of them contains the rules depending on the requirements of each version.
 
-##Installation & Usage
+##Installation
 
-Clone or download this repo somewhere on your computer.
+Install all dependencies via [Composer](https://getcomposer.org):
 ```sh
-$ git clone git@github.com:magento/marketplace-eqp.git
+$ composer create-project --repository=https://repo.magento.com magento/marketplace-eqp magento-coding-standard
 ```
-Install all required dependencies via [Composer](https://getcomposer.org):
+You’re required to authenticate; see [Get your authentication keys](http://devdocs.magento.com/guides/v2.0/install-gde/prereq/connect-auth.html) for details.
+
+##Usage
 ```sh
-$ composer install
-```
-It will add [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) to the `vendor` folder of the project. 
-Go to `/vendor/squizlabs/php_codesniffer` and add MEQP standard's directory to PHP_CodeSniffer installed paths:
-```sh
-$ php scripts/phpcs --config-set installed_paths "/path/to/magento/marketplace-eqp"
+$ cd magento-coding-standard
 ```
 Select the standard to run with PHP_CodeSniffer. To check Magento extension run:
 ```sh
-$ php scripts/phpcs "/path/to/your/extension" --standard=MEQP1
+$ vendor/bin/phpcs /path/to/your/extension --standard=MEQP1
 ```
 To check Magento 2 extension run:
 ```sh
-$ php scripts/phpcs "/path/to/your/extension" --standard=MEQP2
+$ vendor/bin/phpcs /path/to/your/extension --standard=MEQP2
 ```
-By default, PHP_CodeSniffer will check any file it finds with a `.inc`, .`php`, `.js` or `.css` extension. To check design templates, you can specify `.phtml` in the `--extensions` argument: `--extensions=php,phtml`.
+By default, PHP_CodeSniffer will check any file it finds with a `.inc`, .`php`, `.js` or `.css` extension. To check design templates, you can specify `--extensions=php,phtml` option.
 
 To check syntax with specific PHP version set paths to php binary dir:
 ```sh
-$ php scripts/phpcs --config-set php7.0_path "/dir/to/your/php7"
-$ php scripts/phpcs --config-set php5.4_path "/dir/to/your/php5.4"
+$ vendor/bin/phpcs --config-set php7.0_path <dir-to-your-php7>
+$ vendor/bin/phpcs --config-set php5.4_path <dir-to-your-php5.4>
 ```
 #Fixing Errors Automatically
 
 PHP_CodeSniffer offers the PHP Code Beautifier and Fixer (`phpcbf`) tool. It can be used in place of `phpcs` to automatically generate and fix all fixable issues. We highly recommend run following command to fix as many sniff violations as possible:
 ```sh
-$ php scripts/phpcbf "/path/to/your/extension" --standard=MEQP2
+$ vendor/bin/phpcbf /path/to/your/extension --standard=MEQP2
 ```
 #Dynamic Sniffs
 
-Sniffs with complex logic, like MEQP2.Classes.CollectionDependency and MEQP2.SQL.CoreTablesModification require path to installed Magento 2 instance. You can specify it using ```$ php scripts/phpcs --config-set m2-path <path-to-magento2>``` command.
+Sniffs with complex logic, like MEQP2.Classes.CollectionDependency and MEQP2.SQL.CoreTablesModification require path to installed Magento 2 instance. You can specify it by running following command:
+```sh
+$ vendor/bin/phpcs --config-set m2-path <path-to-magento2>
+```
 
 >Notice: Dynamic sniffs will not work without specified ```m2-path``` configuration option.
 
@@ -64,7 +64,7 @@ Sniffs with complex logic, like MEQP2.Classes.CollectionDependency and MEQP2.SQL
 #Marketplace Technical Review
 To make sure, your extension will pass CodeSniffer checks on Level 1 of Magento Marketplace Technical Review, you could run `phpcs` command with `--severity=10` option.
 ```sh
-$ php scripts/phpcs "/path/to/your/extension" --standard=MEQP2 --severity=10
+$ vendor/bin/phpcs /path/to/your/extension --standard=MEQP2 --severity=10
 ```
 **All severity 10 errors must be fixed in order to successfully pass Level 1 CodeSniffer checks.**
  
@@ -72,7 +72,7 @@ $ php scripts/phpcs "/path/to/your/extension" --standard=MEQP2 --severity=10
 
 * PHP >=5.6.0
 * [Composer](https://getcomposer.org)
-* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) >= 2.6.2
+* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 2.6.2
 
 >Notice: PHP and Composer should be accessible globally.
 

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
   "name": "magento/marketplace-eqp",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A set of PHP_CodeSniffer rules and sniffs.",
   "license": "MIT",
   "require": {
     "php": ">=5.6.0",
     "squizlabs/php_codesniffer": "2.6.2",
     "phpunit/phpunit": "4.1.0"
+  },
+  "scripts": {
+    "post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths ../../..",
+    "post-update-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths ../../.."
   }
 }


### PR DESCRIPTION
- fixed #23