### PR TITLE
Add exclusion for *Html methods in MEQP1 XSS sniff

### DIFF
--- a/MEQP1/Sniffs/Templates/XssTemplateSniff.php
+++ b/MEQP1/Sniffs/Templates/XssTemplateSniff.php
@@ -77,7 +77,7 @@ class XssTemplateSniff implements PHP_CodeSniffer_Sniff
      *
      * @var string
      */
-    protected $methodNameContains = '';
+    protected $methodNameContains = 'html';
 
     /**
      * PHP functions, that no need escaping.


### PR DESCRIPTION
We were running into issues where `getChildHtml` calls were being flagged as unescaped output needing fixing, even though they clearly need to output raw HTML. This change fixes the sniff so that it excludes methods with "html" in the name from being flagged.

The sniff already had support for this, but it appears to have only been used in the Magento 2 version, even though it's relevant for Magento 1 as well.