### PR TITLE
MM-620: MEQP1 standard fails on PHP 5.4

### DIFF
--- a/MEQP1/Sniffs/Classes/ResourceModelSniff.php
+++ b/MEQP1/Sniffs/Classes/ResourceModelSniff.php
@@ -98,7 +98,9 @@ class ResourceModelSniff implements PHP_CodeSniffer_Sniff
         static $calledMethods;
         if ($fileName != $phpcsFile->getFilename()) {
             $fileName = $phpcsFile->getFilename();
-            $calledMethods = array_flip(array_column($this->getCalledMethods($phpcsFile), 'content'));
+            $calledMethods = array_flip(array_map(function ($element) {
+                return $element['content'];
+            }, $this->getCalledMethods($phpcsFile)));
         }
         if (isset($calledMethods[$methodName])
             && in_array($methodName, $this->disallowedMethods)
@@ -123,7 +125,9 @@ class ResourceModelSniff implements PHP_CodeSniffer_Sniff
     protected function getNeededPointer(PHP_CodeSniffer_File $phpcsFile)
     {
         $tokens = $phpcsFile->getTokens();
-        return array_search($this->token, array_column($tokens, 'code'));
+        return array_search($this->token, array_map(function ($element) {
+            return $element['code'];
+        }, $tokens));
     }
 
     /**

--- a/MEQP1/Sniffs/SQL/MissedIndexesSniff.php
+++ b/MEQP1/Sniffs/SQL/MissedIndexesSniff.php
@@ -57,7 +57,9 @@ class MissedIndexesSniff implements PHP_CodeSniffer_Sniff
     {
         if (strpos($sourceFile->getFilename(), 'sql') !== false) {
             $methods = $this->getCalledMethods($sourceFile);
-            $methodNames = array_column($methods, 'content');
+            $methodNames = array_map(function ($element) {
+                return $element['content'];
+            }, $methods);
             if (in_array('newTable', $methodNames) && !in_array('addIndex', $methodNames)) {
                 $sourceFile->addWarning($this->warningMessage, $index, $this->warningCode, [], $this->severity);
             }


### PR DESCRIPTION
- Fixed #20
- Removed all uses of 'array_column(...)' function in MEQP1 standard. Replaced it with 'array_map(...)'