### PR TITLE
MM-692: Fix issue with PSR1.Classes.ClassDeclaration sniff for M1

### DIFF
--- a/MEQP1/ruleset.xml
+++ b/MEQP1/ruleset.xml
@@ -11,13 +11,17 @@
             <property name="absoluteLineLimit" value="0"/>
         </properties>
     </rule>
-    <rule ref="Generic.Files.OneClassPerFile"/>
-    <rule ref="Generic.Files.OneInterfacePerFile"/>
     <rule ref="MEQP1.Security.LanguageConstruct.DirectOutput">
         <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
     <rule ref="Squiz.PHP.DiscouragedFunctions"/>
     <rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+        <severity>10</severity>
+    </rule>
+    <rule ref="Generic.Files.OneClassPerFile.MultipleFound">
+        <severity>10</severity>
+    </rule>
+    <rule ref="Generic.Files.OneInterfacePerFile.MultipleFound">
         <severity>10</severity>
     </rule>
     <rule ref="Generic.Functions.CallTimePassByReference.NotAllowed">
@@ -28,9 +32,6 @@
         <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
     <rule ref="Generic.PHP.DeprecatedFunctions.Deprecated">
-        <severity>10</severity>
-    </rule>
-    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <severity>10</severity>
     </rule>
     <rule ref="Squiz.PHP.Eval.Discouraged">

--- a/MEQP2/ruleset.xml
+++ b/MEQP2/ruleset.xml
@@ -6,8 +6,6 @@
         <exclude name="PSR2.Classes.PropertyDeclaration.Underscore"/>
         <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
     </rule>
-    <rule ref="Generic.Files.OneClassPerFile"/>
-    <rule ref="Generic.Files.OneInterfacePerFile"/>
     <rule ref="Generic.WhiteSpace.ScopeIndent">
         <exclude-pattern>*.js</exclude-pattern>
     </rule>


### PR DESCRIPTION
- Fixed #24
- Removed `PSR1.Classes.ClassDeclaration` sniff from MEQP1 ruleset
- Added `Generic.Files.OneClassPerFile.MultipleFound` and `Generic.Files.OneInterfacePerFile.MultipleFound` error codes with `severity 10`