### PR TITLE
Move phpunit to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,9 @@
   "license": "MIT",
   "require": {
     "php": ">=5.6.0",
-    "squizlabs/php_codesniffer": "2.6.2",
+    "squizlabs/php_codesniffer": "2.6.2"
+  },
+  "require-dev": {
     "phpunit/phpunit": "4.1.0"
   },
   "scripts": {


### PR DESCRIPTION
Since phpunit is not required per se for using this coding style it should not be forced upon the developers that want to reference it in their projects. 
Moving phpunit to require-dev has the following benefits:

- no change for standalone installations of this coding style (via git clone & composer install)
- not forcing developers to use ancient phpunit versions who want to refer to this coding standard in projects (via composer require)