### PR TITLE
Exclude phtml files from certain rules

### DIFF
--- a/MEQP2/ruleset.xml
+++ b/MEQP2/ruleset.xml
@@ -150,6 +150,7 @@
     </rule>
     <rule ref="Generic.Files.LineLength.TooLong">
         <severity>6</severity>
+        <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
     <rule ref="Generic.Formatting.DisallowMultipleStatements.SameLine">
         <severity>6</severity>
@@ -186,6 +187,7 @@
     <rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
         <severity>6</severity>
         <type>warning</type>
+        <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
     <rule ref="Generic.PHP.DisallowShortOpenTag.Found">
         <severity>6</severity>
@@ -522,10 +524,12 @@
     <rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis">
         <severity>6</severity>
         <type>warning</type>
+        <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
     <rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword">
         <severity>6</severity>
         <type>warning</type>
+        <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
     <rule ref="Squiz.ControlStructures.ControlSignature.SpaceBeforeSemicolon">
         <severity>6</severity>

--- a/MEQP2/ruleset.xml
+++ b/MEQP2/ruleset.xml
@@ -185,9 +185,7 @@
         <type>warning</type>
     </rule>
     <rule ref="Generic.PHP.DisallowShortOpenTag.EchoFound">
-        <severity>6</severity>
-        <type>warning</type>
-        <exclude-pattern>*.phtml</exclude-pattern>
+        <severity>0</severity>
     </rule>
     <rule ref="Generic.PHP.DisallowShortOpenTag.Found">
         <severity>6</severity>
@@ -524,12 +522,10 @@
     <rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis">
         <severity>6</severity>
         <type>warning</type>
-        <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
     <rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword">
         <severity>6</severity>
         <type>warning</type>
-        <exclude-pattern>*.phtml</exclude-pattern>
     </rule>
     <rule ref="Squiz.ControlStructures.ControlSignature.SpaceBeforeSemicolon">
         <severity>6</severity>


### PR DESCRIPTION
Exclude phtml files from:
- Generic.Files.LineLength.TooLong
- Generic.Formatting.DisallowMultipleStatements.SameLine
- Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis
- Squiz.ControlStructures.ControlSignature.SpaceBeforeSemicolon

See #57 for more info.