### PR TITLE
[WIP] Relative rule references

### DIFF
--- a/MEQP2/ruleset.xml
+++ b/MEQP2/ruleset.xml
@@ -9,26 +9,26 @@
     <rule ref="Generic.WhiteSpace.ScopeIndent">
         <exclude-pattern>*.js</exclude-pattern>
     </rule>
-    <rule ref="MEQP1.Exceptions.Namespace"/>
-    <rule ref="MEQP1.Performance.CollectionCount"/>
-    <rule ref="MEQP1.Performance.EmptyCheck"/>
-    <rule ref="MEQP1.Performance.InefficientMethods"/>
-    <rule ref="MEQP1.Performance.Loop"/>
-    <rule ref="MEQP1.PHP.Goto"/>
-    <rule ref="MEQP1.PHP.Var"/>
-    <rule ref="MEQP1.Security.DiscouragedFunction"/>
-    <rule ref="MEQP1.Security.IncludeFile"/>
-    <rule ref="MEQP1.Security.LanguageConstruct"/>
-    <rule ref="MEQP1.Security.LanguageConstruct.DirectOutput">
-        <exclude-pattern>*.phtml</exclude-pattern>
-    </rule>
-    <rule ref="MEQP1.SQL.RawQuery"/>
-    <rule ref="MEQP1.SQL.SlowQuery"/>
-    <rule ref="MEQP1.Strings.RegEx"/>
-    <rule ref="MEQP1.Strings.StringConcat"/>
-    <rule ref="MEQP1.Strings.StringPosition"/>
+		<rule ref="../MEQP1/Sniffs/Exceptions/NamespaceSniff.php"/>
+    <rule ref="../MEQP1/Sniffs/Performance/CollectionCountSniff.php"/>
+    <rule ref="../MEQP1/Sniffs/Performance/EmptyCheckSniff.php"/>
+    <rule ref="../MEQP1/Sniffs/Performance/InefficientMethodsSniff.php"/>
+    <rule ref="../MEQP1/Sniffs/Performance/LoopSniff.php"/>
+    <rule ref="../MEQP1/Sniffs/PHP/GotoSniff.php"/>
+    <rule ref="../MEQP1/Sniffs/PHP/VarSniff.php"/>
+    <rule ref="../MEQP1/Sniffs/Security/DiscouragedFunctionSniff.php"/>
+    <rule ref="../MEQP1/Sniffs/Security/IncludeFileSniff.php"/>
+    <rule ref="../MEQP1/Sniffs/Security/LanguageConstructSniff.php"/>
+    <!-- <rule ref="../MEQP1/Sniffs/Security/LanguageConstruct/DirectOutputSniff.php"> -->
+    <!--     <exclude-pattern>*.phtml</exclude-pattern> -->
+    <!-- </rule> -->
+		<rule ref="../MEQP1/Sniffs/SQL/RawQuerySniff.php"/>
+    <rule ref="../MEQP1/Sniffs/SQL/SlowQuerySniff.php"/>
+    <rule ref="../MEQP1/Sniffs/Strings/RegExSniff.php"/>
+    <rule ref="../MEQP1/Sniffs/Strings/StringConcatSniff.php"/>
+    <rule ref="../MEQP1/Sniffs/Strings/StringPositionSniff.php"/>
     <rule ref="MEQP2.Classes.ObjectInstantiation">
-        <exclude-pattern>*/Test/*</exclude-pattern>
+        <exclude-pattern>*.Test/*</exclude-pattern>
     </rule>
     <rule ref="MEQP2.Templates.ThisInTemplate">
         <exclude-pattern>*.php</exclude-pattern>


### PR DESCRIPTION
I've changed the ruleset.xml file to use relative references so that these rules can be added as a dependency to an existing magento project with `composer require --dev`.

In this way you don't need to install rules globally and, together with a phpcs.xml file you can drop the setup time and complexity for other teammates, automated pipelines, and so on.

In the past I opened the very same issue in https://github.com/magento-ecg/coding-standard/issues/37

The only thing is that I'm not able to do and need some guidance is to split the  `MEQP1.Security.LanguageConstruct.DirectOutput` Sniff to a different class since relative rule declaration works per file and not per rule.