### PR TITLE
Set extensions list to be checked by default.

### DIFF
--- a/MEQP1/ruleset.xml
+++ b/MEQP1/ruleset.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="MEQP1">
     <description>Magento EQP Coding Standard</description>
+    <!-- File extensions to be checked. -->
+    <arg name="extensions" value="php,phtml"/>
     <!-- Do not check code in the lib folder. -->
     <exclude-pattern>*/lib/*</exclude-pattern>
     <!-- Include the whole Zend standard. -->

--- a/MEQP2/ruleset.xml
+++ b/MEQP2/ruleset.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="MEQP2">
     <description>Magento 2 EQP Coding Standard</description>
+    <!-- File extensions to be checked. -->
+    <arg name="extensions" value="php,phtml"/>
     <!-- Include PSR2 standard. -->
     <rule ref="PSR2">
         <exclude name="PSR2.Classes.PropertyDeclaration.Underscore"/>


### PR DESCRIPTION
By default, PHPCS scans only files with `php`, `inc`, `js` and `css` extensions (hardcoded in [config](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Config.php#L476)).
Magento EQP coding standard needs to scan `php` and `phtml` files.

For now, it leads to problems (ignore of `phtml` files) when there is no possibility to add additional arguments during the scan (for example, in PHP Storm Inspections).

So, it will be good to set `php` and `phtml` extensions by default for our standard.