### PR TITLE
Jenkins will not find any files because MEQP1 excludes all lib folders

### DIFF
--- a/MEQP1/ruleset.xml
+++ b/MEQP1/ruleset.xml
@@ -2,7 +2,7 @@
 <ruleset name="MEQP1">
     <description>Magento EQP Coding Standard</description>
     <!-- Do not check code in the lib folder. -->
-    <exclude-pattern>*/lib/*</exclude-pattern>
+    <exclude-pattern type="relative">^/lib/*</exclude-pattern>
     <!-- Include the whole Zend standard. -->
     <rule ref="Zend"/>
     <rule ref="Generic.Files.LineLength">


### PR DESCRIPTION
I found an issue with running the MEQP1 ruleset in Jenkins because the default Jenkins home directory is `/var/lib/jenkins`. This will cause `<exclude-pattern>*/lib/*</exclude-pattern>` to exclude all files because PHPCS will check the full absolute path which will always include `lib` in a default installation of Jenkins.

The only question I have with this fix is if it makes sense to have the exclude pattern at all.