### PR TITLE
Add new escaping methods from Magento 2.2 to XSS sniff whitelist

### DIFF
--- a/MEQP2/Sniffs/Templates/XssTemplateSniff.php
+++ b/MEQP2/Sniffs/Templates/XssTemplateSniff.php
@@ -25,6 +25,8 @@ class XssTemplateSniff extends \MEQP1\Sniffs\Templates\XssTemplateSniff
         'escapeJsQuote',
         'escapeQuote',
         'escapeXssInUrl',
+        'escapeJs',
+        'escapeCss',
     ];
 
     /**

--- a/MEQP2/Sniffs/Templates/XssTemplateSniff.php
+++ b/MEQP2/Sniffs/Templates/XssTemplateSniff.php
@@ -27,6 +27,7 @@ class XssTemplateSniff extends \MEQP1\Sniffs\Templates\XssTemplateSniff
         'escapeXssInUrl',
         'escapeJs',
         'escapeCss',
+        'getJsLayout'
     ];
 
     /**


### PR DESCRIPTION
`escapeHtmlAttr` is already allowed because it contains "Html"