### PR TITLE
Add new use cases to the unit test for ObjectInstantiationSniff

### DIFF
--- a/MEQP2/Tests/Classes/ObjectInstantiationUnitTest.inc
+++ b/MEQP2/Tests/Classes/ObjectInstantiationUnitTest.inc
@@ -1,32 +1,21 @@
 <?php
-namespace Testsource\Example\Helper;
 
-use \Magento\Framework\App\Config\ScopeConfigInterface;
-use \Magento\Framework\ObjectManagerInterface;
-use \Magento\Framework\Model\Context;
+// not allowed
+$splInstance = new \SplFixedArray();
 
-class TestHelper
-{
-    protected $_objectManager;
-    protected $_tester;
-    protected $order;
+$magentoNamespaceInstance = new Magento\Sales\Model\Order();
 
-    public function __construct(
-        ObjectManagerInterface $objectManager,
-        TesterInterface $tester,
-        Context $context,
-        ScopeConfigInterface $scopeConfig
-    ) {
-        $this->_tester = new TesterHelper($tester, $scopeConfig);
-        $this->_objectManager = $objectManager;
-        $this->order = new \Magento\Sales\Model\Order($context);
-		$this->obj = new \StdObject();
-    }
-	
-	public function test($notification)
-    {
-        if (!$notification->getId()) {
-            throw new \Magento\Framework\Exception\LocalizedException(__('Wrong notification ID specified.'));
-        }
-    }
+$magentoInstance = new Order();
+
+$selfInstance = new self();
+
+$staticInstance = new static();
+
+//allowed
+if ($somethingBad === true) {
+    throw new \Magento\Framework\Exception\LocalizedException(__('Oops'));
+}
+
+if ($somethingVeryBad === true) {
+    throw new \Exception('Ooooops');
 }

--- a/MEQP2/Tests/Classes/ObjectInstantiationUnitTest.php
+++ b/MEQP2/Tests/Classes/ObjectInstantiationUnitTest.php
@@ -26,9 +26,11 @@ class ObjectInstantiationUnitTest extends AbstractSniffUnitTest
     public function getWarningList()
     {
         return [
-            20 => 1,
-            22 => 1,
-            23 => 1,
+            4 => 1,
+            6 => 1,
+            8 => 1,
+            10 => 1,
+            12 => 1,
         ];
     }
 }


### PR DESCRIPTION
- fixed `ObjectInstantiationUnitTest` by adding more explanatory use cases.