### PR TITLE
Add package type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "version": "1.0.5",
   "description": "A set of PHP_CodeSniffer rules and sniffs.",
   "license": "MIT",
+  "type": "phpcodesniffer-standard",
   "require": {
     "php": ">=5.5.0",
     "squizlabs/php_codesniffer": "3.*"


### PR DESCRIPTION
## What

This PR adds a package type to `composer.json`. This does not change the default behavior of this package.

## Why

Setting the type of this package to `"phpcodesniffer-standard"` will allow this package to be automatically processed by composer install plugins. This makes the package easier to use, since the user doesn't have to manually run `phpcs --config-set ...`.

Also see the following wiki article:

https://github.com/Dealerdirect/phpcodesniffer-composer-installer/wiki/Change-%60composer.json%60-%22type%22-to-%60phpcodesniffer-standard%60