### PR TITLE
MM-4660: [EQP-Tools][Sniffs] New MEQP coding standard release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 install: composer install --no-interaction --prefer-source
 script:
   - vendor/bin/phpunit vendor/squizlabs/php_codesniffer/tests/AllTests.php

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "magento/marketplace-eqp",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "description": "A set of PHP_CodeSniffer rules and sniffs.",
   "license": "MIT",
   "type": "phpcodesniffer-standard",


### PR DESCRIPTION
- updated version to `2.0.0`
- added PHP 7.1 to the `.travis.yml`