### PR TITLE
MM-4897: [Dev Portal 2.0] [backend] [tools] use of short array syntax in m1 not triggering warning

### DIFF
--- a/MEQP1/ruleset.xml
+++ b/MEQP1/ruleset.xml
@@ -44,6 +44,7 @@
     </rule>
     <rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
         <severity>8</severity>
+        <type>warning</type>
     </rule>
     <rule ref="Generic.Classes.DuplicateClassName.Found">
         <severity>8</severity>


### PR DESCRIPTION
- changed sniff finding from `error` to `warning`