### PR TITLE
Fix /lib/ ignore ruleset

### DIFF
--- a/MEQP1/ruleset.xml
+++ b/MEQP1/ruleset.xml
@@ -4,7 +4,7 @@
     <!-- File extensions to be checked. -->
     <arg name="extensions" value="php,phtml"/>
     <!-- Do not check code in the lib folder. -->
-    <exclude-pattern type="relative">^/lib/*</exclude-pattern>
+    <exclude-pattern type="relative">^lib/*</exclude-pattern>
     <!-- Include the whole Zend standard. -->
     <rule ref="Zend"/>
     <rule ref="Generic.Files.LineLength">


### PR DESCRIPTION
See #81 , the expected behaviour is: ignoring the '/lib/* directory
the relative path is matched without the starting directory separator.
see https://github.com/squizlabs/PHP_CodeSniffer/blob/master/src/Filters/Filter.php#L221
hence the removal of the starting `/`